### PR TITLE
Update interface for configuring markdown elements 

### DIFF
--- a/Example/Markdowner/ViewController.swift
+++ b/Example/Markdowner/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController {
                 symbolsColor: UIColor.red,
                 useDynamicType: true
             ),
-            headerConfig: .enabled(maxLevel: .h5)
+            headerConfig: .enabled(maxLevel: .max)
         )
     }
     

--- a/Example/Markdowner/ViewController.swift
+++ b/Example/Markdowner/ViewController.swift
@@ -35,8 +35,7 @@ class ViewController: UIViewController {
                 textColor: UIColor.darkGray,
                 symbolsColor: UIColor.red,
                 useDynamicType: true
-            ),
-            headerConfig: .enabled(maxLevel: .max)
+            )
         )
     }
     

--- a/Example/Markdowner/ViewController.swift
+++ b/Example/Markdowner/ViewController.swift
@@ -29,12 +29,14 @@ class ViewController: UIViewController {
         let content = try! String(contentsOf: contentURL)
         
         textView.text = content
-        
-        textView.stylesConfiguration = StylesConfiguration(
-            baseFont: UIFont.systemFont(ofSize: 18),
-            textColor: UIColor.darkGray,
-            symbolsColor: UIColor.red,
-            useDynamicType: true
+        self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+            style: StylesConfiguration(
+                baseFont: UIFont.systemFont(ofSize: 18),
+                textColor: UIColor.darkGray,
+                symbolsColor: UIColor.red,
+                useDynamicType: true
+            ),
+            headerConfig: .enabled(maxLevel: .h5)
         )
     }
     

--- a/Example/Markdowner/ViewController.swift
+++ b/Example/Markdowner/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         let content = try! String(contentsOf: contentURL)
         
         textView.text = content
-        self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+        self.textView.elementsConfig = MarkdownElementsConfig().overriding(
             style: StylesConfiguration(
                 baseFont: UIFont.systemFont(ofSize: 18),
                 textColor: UIColor.darkGray,

--- a/Example/Tests/HeaderElementTests.swift
+++ b/Example/Tests/HeaderElementTests.swift
@@ -86,7 +86,7 @@ class HeaderElementTests: XCTestCase {
     }
     
     func testRegex_DoesNotRecognizeMoreThanMaxLevel() {
-        let element = HeaderElement(symbolsColor: .red, fontProvider: fontProvider, maxLevel: 1)
+        let element = HeaderElement(symbolsColor: .red, fontProvider: fontProvider, maxLevel: .h1)
         
         let markdown = "## Hello"
         
@@ -174,11 +174,11 @@ class HeaderElementTests: XCTestCase {
     }
     
     func testApplyStylesConfiguration_UpdateMaxLevel() {
-        let element = HeaderElement(symbolsColor: .red, fontProvider: fontProvider, maxLevel: 3)
+        let element = HeaderElement(symbolsColor: .red, fontProvider: fontProvider, maxLevel: .h3)
         let configurations = StylesConfiguration.mockConfigurations()
         
         let maxLevels = configurations.map { element.applying(stylesConfiguration: $0).maxLevel }
         
-        XCTAssertEqual(maxLevels, configurations.map { _ in 3 })
+        XCTAssertEqual(maxLevels, configurations.map { _ in .h3 })
     }
 }

--- a/Markdowner/Classes/Default Elements/HeaderElement.swift
+++ b/Markdowner/Classes/Default Elements/HeaderElement.swift
@@ -13,16 +13,14 @@ import Foundation
 open class HeaderElement: MarkdownElement {
     public let symbolsColor: UIColor
     public let fontProvider: HeaderElementFontProvider
-    public let maxLevel: Int
+    public let maxLevel: Level
     
-    public init(symbolsColor: UIColor, fontProvider: HeaderElementFontProvider, maxLevel: Int = 6) {
-        guard maxLevel >= 1 else { fatalError() }
-        
+    public init(symbolsColor: UIColor, fontProvider: HeaderElementFontProvider, maxLevel: Level = .max) {
         self.symbolsColor = symbolsColor
         self.fontProvider = fontProvider
         self.maxLevel = maxLevel
         
-        guard let regex = try? NSRegularExpression(pattern: "^(#{1,\(maxLevel)}) .+", options: .anchorsMatchLines) else {
+        guard let regex = try? NSRegularExpression(pattern: "^(#{1,\(maxLevel.rawValue)}) .+", options: .anchorsMatchLines) else {
             fatalError()
         }
         
@@ -84,7 +82,7 @@ open class HeaderElement: MarkdownElement {
     public enum Level: Int {
         case h1 = 1, h2, h3, h4, h5, h6
         
-        static let maxLevel = Level.h6
+        public static let max = Level.h6
     }
 }
 
@@ -104,7 +102,7 @@ final public class DefaultHeaderElementFontProvider: HeaderElementFontProvider {
     }
     
     public func font(forLevel level: HeaderElement.Level) -> UIFont {
-        let extraSize = CGFloat(HeaderElement.Level.maxLevel.rawValue - level.rawValue)
+        let extraSize = CGFloat(HeaderElement.Level.max.rawValue - level.rawValue)
         let newFont = self.font.withSize(self.font.pointSize + extraSize)
         return useDynamicType ? newFont.dynamic() : newFont
     }

--- a/Markdowner/Classes/MarkdownTextStorage.swift
+++ b/Markdowner/Classes/MarkdownTextStorage.swift
@@ -23,7 +23,7 @@ public class MarkdownTextStorage: NSTextStorage {
     
     private let backingString = NSMutableAttributedString()
 
-    public init(elementsConfig: MarkdownElementsConfig = .defaultConfig()) {
+    public init(elementsConfig: MarkdownElementsConfig = .init()) {
         self.elementsConfig = elementsConfig
         markdownParser = MarkdownParser(markdownElements: elementsConfig.enabledElements())
         super.init()

--- a/Markdowner/Classes/MarkdownTextView.swift
+++ b/Markdowner/Classes/MarkdownTextView.swift
@@ -9,11 +9,9 @@ import Foundation
 
 /// Custom text view class to display text as formatted markdown
 open class MarkdownTextView: UITextView {
-    
-    /// Object used as the style base for the markdown elements
-    public var stylesConfiguration: StylesConfiguration {
-        get { return markdownStorage.stylesConfiguration }
-        set { markdownStorage.stylesConfiguration = newValue }
+    public var elementsConfig: MarkdownElementsConfig {
+        get { return markdownStorage.elementsConfig }
+        set { markdownStorage.elementsConfig = newValue }
     }
     
     private let markdownStorage: MarkdownTextStorage
@@ -35,13 +33,6 @@ open class MarkdownTextView: UITextView {
         // isn't working, even when the Apple docs state that it should be as simple as calling:
         // `markdownStorage.addLayoutManager(self.layoutManager)`
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    /// Indicates to the storage the set of markdown elements that will be used to process the text.
-    ///
-    /// - Parameter elements: Markdown elements to use (they can be custom elements or the default ones).
-    public func use(elements: [MarkdownElement]) {
-        markdownStorage.use(elements: elements)
     }
     
     /// Retrieves an attributted string containing a preview of the content displayed in the text view

--- a/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
+++ b/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
@@ -1,0 +1,175 @@
+//
+//  MarkdownElementsConfiguration.swift
+//  Markdowner
+//
+//  Created by Reynaldo on 6/12/21.
+//
+
+import Foundation
+import UIKit
+
+public struct MarkdownElementsConfig {
+    public let style: StylesConfiguration
+
+    public let boldConfig: SimpleElementConfig
+    public let italicConfig: SimpleElementConfig
+    public let strikethroughConfig: SimpleElementConfig
+    public let headerConfig: HeaderConfig
+    public let bulletConfig: SimpleElementConfig
+    public let linkConfig: LinkConfig
+    public let inlineCodeConfig: InlineCodeConfig
+
+    public let customElements: [MarkdownElement]
+
+    public static func defaultConfig() -> MarkdownElementsConfig {
+        func defaultCodeFont(style: StylesConfiguration) -> UIFont {
+            guard let monospaceFont = UIFont(name: "Menlo-Regular", size: style.baseFont.pointSize) else {
+                assertionFailure("Menlo font isn't available")
+                return style.baseFont
+            }
+
+            return monospaceFont
+        }
+
+        let style = StylesConfiguration.default
+
+        return MarkdownElementsConfig(
+            style: style,
+            boldConfig: .enabled,
+            italicConfig: .enabled,
+            strikethroughConfig: .enabled,
+            headerConfig: .enabled(maxLevel: .max),
+            bulletConfig: .enabled,
+            linkConfig: .enabled(linkColor: UIColor.lightGray),
+            inlineCodeConfig: .enabled(codeFont: defaultCodeFont(style: style)),
+            customElements: []
+        )
+    }
+
+    public func overriding(
+        style: StylesConfiguration? = nil,
+        boldConfig: SimpleElementConfig? = nil,
+        italicConfig: SimpleElementConfig? = nil,
+        strikethroughConfig: SimpleElementConfig? = nil,
+        headerConfig: HeaderConfig? = nil,
+        bulletConfig: SimpleElementConfig? = nil,
+        linkConfig: LinkConfig? = nil,
+        inlineCodeConfig: InlineCodeConfig? = nil,
+        customElements: [MarkdownElement]? = nil
+    ) -> MarkdownElementsConfig {
+        return MarkdownElementsConfig(
+            style: style ?? self.style,
+            boldConfig: boldConfig ?? self.boldConfig,
+            italicConfig: italicConfig ?? self.italicConfig,
+            strikethroughConfig: strikethroughConfig ?? self.strikethroughConfig,
+            headerConfig: headerConfig ?? self.headerConfig,
+            bulletConfig: bulletConfig ?? self.bulletConfig,
+            linkConfig: linkConfig ?? self.linkConfig,
+            inlineCodeConfig: inlineCodeConfig ?? self.inlineCodeConfig,
+            customElements: customElements ?? self.customElements
+        )
+    }
+
+    public func enabledElements() -> [MarkdownElement] {
+        let standardElements = [
+            boldElement(),
+            italicElement(),
+            strikethroughElement(),
+            headerElement(),
+            bulletElement(),
+            linkElement(),
+            inlineElement()
+        ].compactMap { $0 }
+
+        return standardElements + customElements
+    }
+
+    // MARK: - Instantiate standard elements
+    private func boldElement() -> BoldElement? {
+        guard case .enabled = boldConfig else {
+            return nil
+        }
+
+        return BoldElement(symbolsColor: style.symbolsColor)
+    }
+
+    private func italicElement() -> ItalicElement? {
+        guard case .enabled = italicConfig else {
+            return nil
+        }
+
+        return ItalicElement(symbolsColor: style.symbolsColor)
+    }
+
+    private func strikethroughElement() -> StrikethroughElement? {
+        guard case .enabled = strikethroughConfig else {
+            return nil
+        }
+
+        return StrikethroughElement(symbolsColor: style.symbolsColor)
+    }
+
+    private func headerElement() -> HeaderElement? {
+        guard case let .enabled(maxLevel) = headerConfig else {
+            return nil
+        }
+
+        return HeaderElement(
+            symbolsColor: style.symbolsColor,
+            fontProvider: DefaultHeaderElementFontProvider(
+                font: style.baseFont,
+                useDynamicType: style.useDynamicType
+            ),
+            maxLevel: maxLevel
+        )
+    }
+
+    private func bulletElement() -> BulletElement? {
+        guard case .enabled = bulletConfig else {
+            return nil
+        }
+
+        return BulletElement(
+            symbolsColor: style.symbolsColor,
+            textColor: style.textColor,
+            font: style.baseFont,
+            useDynamicType: style.useDynamicType
+        )
+    }
+
+    private func linkElement() -> LinkElement? {
+        guard case let .enabled(linkColor) = linkConfig else {
+            return nil
+        }
+
+        return LinkElement(symbolsColor: style.symbolsColor, font: style.baseFont, linksColor: linkColor)
+    }
+
+    private func inlineElement() -> InlineCodeElement? {
+        guard case let .enabled(codeFont) = inlineCodeConfig else {
+            return nil
+        }
+
+        return InlineCodeElement(symbolsColor: style.symbolsColor, font: codeFont, useDynamicType: style.useDynamicType)
+    }
+}
+
+public enum SimpleElementConfig {
+    case enabled
+    case disabled
+}
+
+public enum HeaderConfig {
+    case enabled(maxLevel: HeaderElement.Level)
+    case disabled
+}
+
+public enum LinkConfig {
+    case enabled(linkColor: UIColor)
+    case disabled
+}
+
+public enum InlineCodeConfig {
+    case enabled(codeFont: UIFont)
+    case disabled
+}

--- a/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
+++ b/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
@@ -81,7 +81,7 @@ public struct MarkdownElementsConfig {
             inlineElement()
         ].compactMap { $0 }
 
-        return standardElements + customElements
+        return standardElements + customElements.map { $0.applying(stylesConfiguration: style) }
     }
 
     // MARK: - Instantiate standard elements

--- a/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
+++ b/Markdowner/Classes/Models/MarkdownElementsConfiguration.swift
@@ -21,31 +21,6 @@ public struct MarkdownElementsConfig {
 
     public let customElements: [MarkdownElement]
 
-    public static func defaultConfig() -> MarkdownElementsConfig {
-        func defaultCodeFont(style: StylesConfiguration) -> UIFont {
-            guard let monospaceFont = UIFont(name: "Menlo-Regular", size: style.baseFont.pointSize) else {
-                assertionFailure("Menlo font isn't available")
-                return style.baseFont
-            }
-
-            return monospaceFont
-        }
-
-        let style = StylesConfiguration.default
-
-        return MarkdownElementsConfig(
-            style: style,
-            boldConfig: .enabled,
-            italicConfig: .enabled,
-            strikethroughConfig: .enabled,
-            headerConfig: .enabled(maxLevel: .max),
-            bulletConfig: .enabled,
-            linkConfig: .enabled(linkColor: UIColor.lightGray),
-            inlineCodeConfig: .enabled(codeFont: defaultCodeFont(style: style)),
-            customElements: []
-        )
-    }
-
     public func overriding(
         style: StylesConfiguration? = nil,
         boldConfig: SimpleElementConfig? = nil,
@@ -151,6 +126,29 @@ public struct MarkdownElementsConfig {
         }
 
         return InlineCodeElement(symbolsColor: style.symbolsColor, font: codeFont, useDynamicType: style.useDynamicType)
+    }
+}
+
+public extension MarkdownElementsConfig {
+    init() {
+        func defaultCodeFont(style: StylesConfiguration) -> UIFont {
+            guard let monospaceFont = UIFont(name: "Menlo-Regular", size: style.baseFont.pointSize) else {
+                assertionFailure("Menlo font isn't available")
+                return style.baseFont
+            }
+
+            return monospaceFont
+        }
+
+        style = StylesConfiguration.default
+        boldConfig = .enabled
+        italicConfig = .enabled
+        strikethroughConfig = .enabled
+        headerConfig = .enabled(maxLevel: .max)
+        bulletConfig = .enabled
+        linkConfig = .enabled(linkColor: UIColor.lightGray)
+        inlineCodeConfig = .enabled(codeFont: defaultCodeFont(style: style))
+        customElements = []
     }
 }
 

--- a/Markdowner/Classes/Models/StyleConfiguration.swift
+++ b/Markdowner/Classes/Models/StyleConfiguration.swift
@@ -9,7 +9,13 @@ import Foundation
 
 /// Object used to provide a common look and feel to the markdown text.
 open class StylesConfiguration {
-    
+    public static let `default` = StylesConfiguration(
+        baseFont: UIFont.systemFont(ofSize: 14),
+        textColor: .black,
+        symbolsColor: .blue,
+        useDynamicType: true
+    )
+
     /// Base font that will be used to display the markdown content.
     public let baseFont: UIFont
     

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ textView.text = ... // set the initial markdown to display, if any
 If you want to customize the default look of the markdown elements, you can use the class `MarkdownElementsConfig`.
 
 ```swift
-textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+textView.elementsConfig = MarkdownElementsConfig().overriding(
     style: StylesConfiguration(
         baseFont: UIFont.systemFont(ofSize: 18),
         textColor: UIColor.darkGray,
@@ -51,7 +51,7 @@ textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
 You can also choose which standard markdown elements are available and how they will work. The following example recognizes headers from level 1 to 3, and disable links:
 
 ```swift
-self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+self.textView.elementsConfig = MarkdownElementsConfig().overriding(
     headerConfig: .enabled(maxLevel: .h3),
     linkConfig: .disabled
 )
@@ -60,7 +60,7 @@ self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding
 Creating custom elements is as simple as subclassing the type `MarkdownElement`, and then provide instances of those custom elements via the same `overriding` function:
 
 ```swift
-self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+self.textView.elementsConfig = MarkdownElementsConfig().overriding(
     customElements: [CustomElement1(), CustomElement2()]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Markdowner
 
-[![CI Status](https://img.shields.io/travis/rlaguilar/Markdowner.svg?style=flat)](https://travis-ci.org/rlaguilar/Markdowner)
 [![Version](https://img.shields.io/cocoapods/v/Markdowner.svg?style=flat)](https://cocoapods.org/pods/Markdowner)
 [![License](https://img.shields.io/cocoapods/l/Markdowner.svg?style=flat)](https://cocoapods.org/pods/Markdowner)
 [![Platform](https://img.shields.io/cocoapods/p/Markdowner.svg?style=flat)](https://cocoapods.org/pods/Markdowner)
@@ -39,16 +38,35 @@ textView.text = ... // set the initial markdown to display, if any
 If you want to customize the default look of the markdown elements, you can use the class `StylesConfiguration`.
 
 ```swift
-textView.stylesConfiguration = StylesConfiguration(
-    baseFont: UIFont.systemFont(ofSize: 18),
-    textColor: UIColor.darkGray,
-    symbolsColor: UIColor.red
+textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+    style: StylesConfiguration(
+        baseFont: UIFont.systemFont(ofSize: 18),
+        textColor: UIColor.darkGray,
+        symbolsColor: UIColor.red,
+        useDynamicType: true
+    )
 )
 ```
 
-Creating custom elements is as simple as subclassing the type `MarkdownElement`, and then calling the function `textView.use(elements: [MarkdownElement])` passing as arguments the list of markdown elements that you want to use. As a guide for creating new elements you could use any of the already implemented ones inside the folder `Markdowner/Classes/Default Elements`.
+You can also choose which standard markdown elements are available and how they will work. The following example only recognizes headers from level 1 to 3, and disable links:
 
-It's important to note that for now `Markdowner` doesn't support initialization from Storyboards.
+```swift
+self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+    headerConfig: .enabled(maxLevel: .h3),
+    linkConfig: .disabled
+)
+```
+
+Creating custom elements is as simple as subclassing the type `MarkdownElement`, and then provide instances of those custom elements via the same `overriding` function:
+
+```swift
+self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
+    customElements: [CustomElement1(), CustomElement2]
+)
+
+As a guide for creating new elements, you could use any of the already implemented ones inside the folder `Markdowner/Classes/Default Elements`.
+
+> NOTE: `Markdowner` doesn't support initialization from Storyboards currently.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ textView.text = ... // set the initial markdown to display, if any
 
 ```
 
-If you want to customize the default look of the markdown elements, you can use the class `StylesConfiguration`.
+If you want to customize the default look of the markdown elements, you can use the class `MarkdownElementsConfig`.
 
 ```swift
 textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
@@ -48,7 +48,7 @@ textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
 )
 ```
 
-You can also choose which standard markdown elements are available and how they will work. The following example only recognizes headers from level 1 to 3, and disable links:
+You can also choose which standard markdown elements are available and how they will work. The following example recognizes headers from level 1 to 3, and disable links:
 
 ```swift
 self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
@@ -61,8 +61,9 @@ Creating custom elements is as simple as subclassing the type `MarkdownElement`,
 
 ```swift
 self.textView.elementsConfig = MarkdownElementsConfig.defaultConfig().overriding(
-    customElements: [CustomElement1(), CustomElement2]
+    customElements: [CustomElement1(), CustomElement2()]
 )
+```
 
 As a guide for creating new elements, you could use any of the already implemented ones inside the folder `Markdowner/Classes/Default Elements`.
 


### PR DESCRIPTION
The current library interface isn't very flexible because it doesn't provide a granular way to specify the elements we want to work with. If we want to add a custom element or ignore one of the standard ones, we need to pass all the operators to the function `textView.use(elements: [MarkdownElement])`.

Take a look at the updated [Readme](https://github.com/rlaguilar/Markdowner/blob/update-api/README.md) file in this PR to see how the new API looks like.